### PR TITLE
fix: improve property check and URL regex

### DIFF
--- a/chatmem0-extension/src/common/utils.ts
+++ b/chatmem0-extension/src/common/utils.ts
@@ -153,8 +153,8 @@ export function deepClone<T>(obj: T): T {
   if (obj instanceof Object) {
     const clonedObj: any = {};
     for (const key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        clonedObj[key] = deepClone(obj[key]);
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        clonedObj[key] = deepClone((obj as any)[key]);
       }
     }
     return clonedObj;

--- a/chatmem0-extension/src/content/tongyi.ts
+++ b/chatmem0-extension/src/content/tongyi.ts
@@ -45,7 +45,7 @@ class TongyiExtractor extends BaseExtractor {
   
   private extractConversationId(): string {
     // 尝试从URL提取会话ID
-    const urlMatch = window.location.href.match(/conversation[\/\-]([a-zA-Z0-9]+)/);
+    const urlMatch = window.location.href.match(/conversation[/-]([a-zA-Z0-9]+)/);
     if (urlMatch) return urlMatch[1];
     
     // 尝试从页面数据属性获取


### PR DESCRIPTION
## Summary
- avoid failing on objects lacking `hasOwnProperty` in `deepClone`
- simplify conversation ID regex to remove redundant escaping

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895db57ddfc8323a55b80905bb297c4